### PR TITLE
Allowing app to run even if no file has been loaded so it will create it

### DIFF
--- a/DBDMN/StatSaver.cs
+++ b/DBDMN/StatSaver.cs
@@ -55,8 +55,11 @@ namespace DBDMN
         public static void load()
         {
             // Exit if no stats file
-            if ( !File.Exists( filePath ) )
+            if (!File.Exists(filePath))
+            {
+                bStatsLoaded = true;
                 return;
+            }
 
             Dbg.assert( Stats.getGames().Count == 0, "Trying to load stats while they are already loaded, " +
                 "might lose loaded stats");


### PR DESCRIPTION
Allows the app to work normally if no stats have been found. Which allows it to create the stats file instead of refusing to save at all.
Fixes #1 